### PR TITLE
fix: retry Wikidata queries with exponential backoff

### DIFF
--- a/scripts/build-catalog-wikidata-only.ts
+++ b/scripts/build-catalog-wikidata-only.ts
@@ -66,22 +66,35 @@ interface MovieSummary {
   isStreamable: boolean;
 }
 
+async function fetchWithRetry(url: string, options: RequestInit, maxRetries = 3): Promise<Response> {
+  for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    const response = await fetch(url, options);
+    if (response.ok) return response;
+
+    const isRetryable = response.status >= 500 || response.status === 429;
+    if (!isRetryable || attempt === maxRetries) {
+      throw new Error(`Wikidata query failed: ${response.status} ${response.statusText}`);
+    }
+
+    const delay = Math.min(1000 * 2 ** attempt, 30000);
+    console.log(`Attempt ${attempt}/${maxRetries} failed (${response.status}), retrying in ${delay / 1000}s...`);
+    await new Promise((r) => setTimeout(r, delay));
+  }
+  throw new Error('Unreachable');
+}
+
 async function main() {
   console.log('Querying Wikidata for B&W films...');
 
   const url = new URL(SPARQL_ENDPOINT);
   url.searchParams.set('query', SPARQL_QUERY);
 
-  const response = await fetch(url.toString(), {
+  const response = await fetchWithRetry(url.toString(), {
     headers: {
       Accept: 'application/sparql-results+json',
       'User-Agent': 'BWCinema/1.0 (https://github.com/corvid-agent/bw-cinema)',
     },
   });
-
-  if (!response.ok) {
-    throw new Error(`Wikidata query failed: ${response.status} ${response.statusText}`);
-  }
 
   const data = await response.json() as {
     results: {


### PR DESCRIPTION
## Summary
- Adds retry logic (up to 3 attempts with exponential backoff) to the Wikidata SPARQL fetch in `build-catalog-wikidata-only.ts`
- Retries on 5xx server errors and 429 rate-limit responses, which are transient
- Backoff delays: 2s, 4s (capped at 30s)

## Context
The `Rebuild Catalog` CI workflow failed with a `504 Gateway Timeout` from Wikidata's query service ([run log](https://github.com/corvid-agent/bw-cinema/actions/runs/22538012757/job/65288773096)). This is a known intermittent issue with the Wikidata SPARQL endpoint.

Fixes #4

## Test plan
- [x] Verify the script still builds the catalog successfully when Wikidata responds normally
- [ ] Re-run the `Rebuild Catalog` workflow to confirm it passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)